### PR TITLE
feat: use ImageSize enum for card image size

### DIFF
--- a/pages/home/script.js
+++ b/pages/home/script.js
@@ -1,4 +1,4 @@
-import { createCardWithCarousel } from '../../utils/helper.js';
+import { ImageSize, createCardWithCarousel } from '../../utils/helper.js';
 import { getMovieDiscover, getTVDiscover } from '../../utils/tmdb.js';
 
 const movieCarouselContainer = $("#movie-carousel .carousel-inner");
@@ -10,13 +10,13 @@ var tvScrollPosition = 0;
 
 await getMovieDiscover().then(data => {
     data.results.slice(0, 10).forEach((movie, index) => {
-        $('.movie-collection').append(createCardWithCarousel(movie, index));
+        $('.movie-collection').append(createCardWithCarousel(movie, index, ImageSize.SMALL));
     })
 });
 
 await getTVDiscover().then(data => {
     data.results.slice(0, 10).forEach((tv, index) => {
-        $('.tv-collection').append(createCardWithCarousel(tv, index));
+        $('.tv-collection').append(createCardWithCarousel(tv, index, ImageSize.SMALL));
     });
 });
 

--- a/pages/search/script.js
+++ b/pages/search/script.js
@@ -1,4 +1,4 @@
-import { createCard } from '../../utils/helper.js';
+import { ImageSize, createCard } from '../../utils/helper.js';
 import { getMovieData, getTVData } from '../../utils/tmdb.js';
 
 $(() => {
@@ -51,7 +51,7 @@ $(() => {
 
             data.results.forEach(result => {
                 const col = $('<div class="col-sm-4 col-md-3 col-lg-2 my-2"></div>');
-                const card = createCard(result);
+                const card = createCard(result, ImageSize.SMALL);
                 col.append(card);
                 row.append(col);
             });

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -1,19 +1,28 @@
 export const api_key = '6a8bc9c90e6aefc939e86ed670e5c1b8';
 
-export function createCardWithCarousel(media, index) {
+export const ImageSize = {
+    SMALL: {
+        size: 'w500',
+        baseUrl: 'https://image.tmdb.org/t/p/w500',
+    },
+    ORIGINAL: {
+        size: 'original',
+        baseUrl: 'https://image.tmdb.org/t/p/original',
+    },
+};
+
+export function createCardWithCarousel(media, index, ImageSize) {
     return `
 <div class="carousel-item${index === 0 ? ' active' : ''}">
-    <div class="card">
-        <img class="card-img img-fluid" src="https://image.tmdb.org/t/p/original${media.poster_path}" alt="${media.title}">
-    </div>
+    ${createCard(media, ImageSize)}
 </div>
 `
 };
 
-export function createCard(media) {
+export function createCard(media, ImageSize) {
     return `
 <div class="card">
-    <img class="card-img img-fluid" src="https://image.tmdb.org/t/p/original${media.poster_path}" alt="${media.title}">
+    <img class="card-img img-fluid" src="${ImageSize.baseUrl}${media.poster_path}" alt="${media.title}">
 </div>
 `
 };


### PR DESCRIPTION
Introduce ImageSize enums.

This allows to use specific image size for pages.
This intended to speed the fetching image where the page has a lot of images.